### PR TITLE
finally fixed that nasty memory leak :)

### DIFF
--- a/src/instruction.cpp
+++ b/src/instruction.cpp
@@ -22,6 +22,12 @@ Instruction::Instruction() {
 Instruction *Instruction::copy(){
 	Instruction *r = new Instruction();
 	memcpy(r, this, (sizeof(Instruction) - MAX_ARG_LEN) + arglen);
+	for(int i=0;i<3;i++) {
+		if(buffers[i].buffer) {
+			r->buffers[i].buffer = (byte*) malloc(buffers[i].len);
+			memcpy(r->buffers[i].buffer, buffers[i].buffer, buffers[i].len);
+		}
+	}
 	return r;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,13 +171,16 @@ bool App::tick()
 	}
 	
 	for(int i=0;i<(int)thisFrame->size();i++){
+		bool mustdelete = false;
 		Instruction *iter = (*thisFrame)[i];
+		if(iter->id==CGL_REPEAT_INSTRUCTION)
+			mustdelete = true;
 		//LOG_INSTRUCTION(iter);
 		iter->clear();
 
 		// this has to be deleted on renderers only
 		// because they dynamically copy instructions in DeltaDecodeModule
-		if(!bIsIntercept)
+		if(!bIsIntercept || mustdelete)
 			delete iter;
 	}
 	thisFrame->clear();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,7 +174,13 @@ bool App::tick()
 		Instruction *iter = (*thisFrame)[i];
 		//LOG_INSTRUCTION(iter);
 		iter->clear();
+
+		// this has to be deleted on renderers only
+		// because they dynamically copy instructions in DeltaDecodeModule
+		if(!bIsIntercept)
+			delete iter;
 	}
+	thisFrame->clear();
 
 	delete thisFrame;
 	

--- a/src/mod_delta.cpp
+++ b/src/mod_delta.cpp
@@ -108,15 +108,22 @@ bool DeltaDecodeModule::process(vector<Instruction *> *list){
 				uint32_t *num = (uint32_t *)instr->args;								
 				for(int i=0;i<(int)*num;i++){
 					Instruction *last = lastFrame[instrCount];
-					result->push_back(last->copy());	
-					instrCount++;				
+					// we have to copy here because otherwise lru-processing
+					// would fail if we just saved another reference to
+					// the same instruction ...
+					result->push_back(last->copy());
+					instrCount++;
 				}
 			}else{
-				result->push_back(instr);
+				// ... but then we _have_ to copy here as well
+				// (otherwise we would mess up dynamically created
+				// with static referenced objects in one list)
+				result->push_back(instr->copy());
 				instrCount++;
 			}
 		}else{
-			result->push_back(instr);
+			// ... and here (same reason)
+			result->push_back(instr->copy());
 			instrCount++;
 		}
 	}
@@ -144,6 +151,11 @@ bool DeltaDecodeModule::process(vector<Instruction *> *list){
 		}
 	}
 	
+	for(int n=0;n<(int)list->size();n++) {
+		Instruction *iter = (*list)[n];
+		iter->clear();
+	}
+
 	delete list;
 			
 


### PR DESCRIPTION
Hey Paul,
After some hours of intense code starring and trying to understand the magic :) i finally found that nasty memory leak in the renderer. I have commented the main parts.
The problem was, that thisFrame turned from a vector only referencing elements of the static array in NetSrvModule into one that also referenced dynamically created instructions (when copying some repeated instructions in DeltaEncodeModules process method). Those copied instructions where never deleted afterwards. I fixed it now so that on the renderer site we allways deal with a vector containing only dynamic elements (that have to be deleted then in main.cpp) after the NetSrvModule. Therefor i also had to fully deep copy the Instructions.

Hope you like it.

Btw. i'm pretty excited that you keep up with clustergl. Thanks for that.

Regards
Stephan
