### PR TITLE
Allow GLubyte as type for pushParam in mod_app

### DIFF
--- a/src/mod_app.cpp
+++ b/src/mod_app.cpp
@@ -242,6 +242,7 @@ PUSHPARAM(GLint);
 //PUSHPARAM(GLenum);
 //PUSHPARAM(GLsizei);
 PUSHPARAM(GLbyte);
+PUSHPARAM(GLubyte);
 //PUSHPARAM(GLboolean);
 PUSHPARAM(GLdouble);
 


### PR DESCRIPTION
Allow GLubyte as type for pushParam in mod_app. Otherwise it is
interpreted as GLuint/GLint and leads to bugs, e.g. in glColor4ub()
function (and the whole data stream could be corrupted too)
